### PR TITLE
Upgrade Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eslint-config-goodway
 
 Node: `goodway/node`
+
 Frontend: `goodway/frontend` (doesn't exist)
+
 ES5: `goodway/es5`

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/GoodwayGroup/eslint-config-goodway#readme",
   "dependencies": {
-    "eslint": "^3.10.0",
-    "eslint-config-airbnb-base": "^10.0.1",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint": "^5.4.0",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "^2.14.0"
   }
 }


### PR DESCRIPTION
This was spawned out of the following message coming from the lint in `service-pdf`.

```
(node:4893) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "node_modules/eslint-config-goodway/node_modules/eslint-config-airbnb-base/index.js")
```

TODO: Migrate from shippable to circle. Didn't realize it was still on it.