### PR TITLE
add object curly newline restrictions

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -10,6 +10,7 @@ module.exports = {
     rules: {
       'comma-dangle': 'off',
       indent: ['error', 4],
-      'no-param-reassign': ['error', { 'props': false }]
+      'no-param-reassign': ['error', { 'props': false }],
+      'object-curly-newline': ['error',  { 'multline': true, 'consistent': true }]
     }
 };


### PR DESCRIPTION
Going to leave this up for a few days to give as many people as possible the chance to get a glance considering it's going to cost everyone a `yarn lint:fix`

Cleans up the way we do object assignments, especially object destructuring.

Specifically to avoid cases like
```
const foo = { firstKey,
    whyNotPut, threeKeysOn, thisLineBecause
    youHateYourTeammates
}
```

in favor of the objectively aesthetically superior

```
const foo = {
    eachKeyGets,
    itsOwnLine,
    isntItGreat
}

```

or if it all fits on one line
`const foo = { imACompact, deconstructedObject }`

Uses this setting https://eslint.org/docs/rules/object-curly-newline#consistent
And this setting https://eslint.org/docs/rules/object-curly-newline#multiline

