### PR TITLE
fix: Resolve plugin version conflicts

### DIFF
--- a/react-hooks.js
+++ b/react-hooks.js
@@ -9,7 +9,6 @@ module.exports = {
     require.resolve('eslint-config-airbnb'),
     require.resolve('eslint-config-airbnb/rules/react-hooks'),
     'plugin:storybook/recommended',
-    'plugin:react/jsx-runtime',
   ],
   overrides: [
     {


### PR DESCRIPTION
## Description

Removes `plugin:react/jsx-runtime` to resolve conflicts with the airbnb eslint config. All of the rules covered in jsx-runtime are already covered in the airbnb config.

