### PR TITLE
fix: MS-52 updating JSX settings for React 17+

### DIFF
--- a/react-hooks.js
+++ b/react-hooks.js
@@ -77,6 +77,8 @@ module.exports = {
       ignoreRestSiblings: true,
       destructuredArrayIgnorePattern: '^_',
     }],
+    'react/react-in-jsx-scope': 'off',
+    'react/jsx-uses-react': 'off',
     'react/function-component-definition': 'off',
     'react/jsx-boolean-value': 'off',
     'react/jsx-props-no-spreading': 'warn',


### PR DESCRIPTION
## Description

Fixing regression with the last fix. Although the settings were in the airbnb config, they are setup for the old JSX rendering. These settings need to be turned off to take advantage of React 17+ new JSX renderer.

